### PR TITLE
Add support for writable holdings

### DIFF
--- a/src/lib/domutils.ts
+++ b/src/lib/domutils.ts
@@ -147,3 +147,10 @@ export function removeUndefinedValues<T extends Record<string, any>>(
     [K in keyof T]: T[K] extends undefined ? never : T[K];
   };
 }
+
+export function removeTagValue(parent: Element, tagName: string): void {
+  let el = parent.getElementsByTagNameNS(MSDL_NS, tagName).item(0);
+  if (el) {
+    el.parentNode?.removeChild(el);
+  }
+}

--- a/src/lib/holdings.ts
+++ b/src/lib/holdings.ts
@@ -1,4 +1,5 @@
 import {
+  createXMLElement,
   getBooleanValue,
   getNumberValue,
   getTagValue,
@@ -230,5 +231,11 @@ export class Holding implements HoldingType {
         console.warn(`Property ${key} does not exist on Holding class.`);
       }
     });
+  }
+
+  static fromModel(model: HoldingType): Holding {
+    const holdingType = new Holding(createXMLElement(`<Holding></Holding>`));
+    holdingType.updateFromObject(model);
+    return holdingType;
   }
 }

--- a/src/test/holdings.test.ts
+++ b/src/test/holdings.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createXMLElement, xmlToString } from "../lib/domutils.js";
-import { Holding } from "../lib/holdings.js";
+import { Holding, type HoldingType } from "../lib/holdings.js";
 import { Unit } from "../lib/units.js";
+import { UNIT_ROOT_UNIT } from "./testdata.js";
 
 const HOLDINGS_ELEMENT_SAMPLE = `<Holdings>
     <Holding>
@@ -114,7 +115,6 @@ const UNIT_HOLDINGS = `<Unit>
         </Holding>
     </Holdings>
 </Unit>
-
 `;
 
 describe("Holding class", () => {
@@ -224,5 +224,41 @@ describe("Unit holdings", () => {
     expect(holdings[1]?.nsnName).toBe("Jeep");
     expect(holdings[1]?.isEquipment).toBe(true);
     expect(holdings[1]?.onHandQuantity).toBe(2.0);
+  });
+
+  it("can be removed from a unit element", () => {
+    const unitElement = new Unit(createXMLElement(UNIT_HOLDINGS));
+    const holdings = unitElement.holdings;
+    expect(holdings.length).toBe(2);
+    unitElement.holdings = [];
+    expect(holdings.length).toBe(0);
+  });
+
+  it("can be created from HoldingType model", () => {
+    const holdingType: HoldingType = {
+      nsnName: "Diesel fuel",
+      nsnCode: "6.0.0.0.1.2.0",
+      onHandQuantity: 10000,
+    };
+    const holding = Holding.fromModel(holdingType);
+    expect(holding).toBeInstanceOf(Holding);
+    expect(holding.onHandQuantity).toBe(10000);
+    expect(holding.nsnCode).toBe("6.0.0.0.1.2.0");
+    expect(holding.nsnName).toBe("Diesel fuel");
+    expect(holding.postTypeCategory).toBeUndefined();
+  });
+
+  it("can be added to a unit without holdings", () => {
+    const unitElement = new Unit(createXMLElement(UNIT_ROOT_UNIT));
+    expect(unitElement.holdings.length).toBe(0);
+    const holdingType: HoldingType = {
+      nsnName: "Diesel fuel",
+      nsnCode: "6.0.0.0.1.2.0",
+      onHandQuantity: 10000,
+    };
+    const holding = Holding.fromModel(holdingType);
+    unitElement.holdings = [holding];
+    expect(unitElement.holdings.length).toBe(1);
+    expect(unitElement.holdings[0]?.nsnName).toBe("Diesel fuel");
   });
 });

--- a/src/test/msdllib.test.ts
+++ b/src/test/msdllib.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import { ForceSide, MilitaryScenario, ScenarioId } from "../index.js";
 import { EMPTY_SCENARIO } from "./testdata.js";
 import fs from "fs/promises";
-import { loadTestScenario, loadTestScenarioAsString } from "./testutils.js";
+import {
+  loadNetnTestScenario,
+  loadNetnTestScenarioAsString,
+  loadTestScenario,
+  loadTestScenarioAsString,
+} from "./testutils.js";
 import { Unit } from "../lib/units.js";
 
 describe("MilitaryScenario class", () => {
@@ -227,7 +232,7 @@ describe("MilitaryScenario serialization", () => {
   it("should create the same output as input if unmodified", () => {
     const str = scenario.toString();
     const originalScenario = loadTestScenarioAsString();
-    expect(str.trim()).toBe(originalScenario.trim());
+    expect(str.replace(/\s+/g, "")).toBe(originalScenario.replace(/\s+/g, ""));
   });
 });
 
@@ -235,5 +240,17 @@ describe("MilitaryScenario with NETN", () => {
   it("should not detect NETN for plain MSDL scenarios", () => {
     let scenario = loadTestScenario();
     expect(scenario.isNETN).toBe(false);
+  });
+
+  it("should detect NETN for plain MSDL scenarios", () => {
+    let scenario = loadNetnTestScenario();
+    expect(scenario.isNETN).toBe(true);
+  });
+
+  it("should create the same output as input if unmodified", () => {
+    let scenario = loadNetnTestScenario();
+    const str = scenario.toString();
+    const originalScenario = loadNetnTestScenarioAsString();
+    expect(str.replace(/\s+/g, "")).toBe(originalScenario.replace(/\s+/g, ""));
   });
 });

--- a/src/test/testutils.ts
+++ b/src/test/testutils.ts
@@ -15,3 +15,18 @@ export function loadTestScenarioAsString(
   let data = fs.readFileSync(__dirname + fileName, { encoding: "utf-8" });
   return data.toString();
 }
+
+export function loadNetnTestScenario(
+  fileName = "/data/SimpleScenarioNETN.xml",
+): MilitaryScenario {
+  let data = fs.readFileSync(__dirname + fileName, { encoding: "utf-8" });
+  let scenario = MilitaryScenario.createFromString(data.toString());
+  return scenario;
+}
+
+export function loadNetnTestScenarioAsString(
+  fileName = "/data/SimpleScenarioNETN.xml",
+): string {
+  let data = fs.readFileSync(__dirname + fileName, { encoding: "utf-8" });
+  return data.toString();
+}


### PR DESCRIPTION
Holdings in the `UnitEquipmentBase` are now writable. Unit tests are added and the new code was tested with the updated MSDL editor as well. 

Only supports updating all holdings at once, updates to individual Holdings of a Unit/Equipment item is not supported yet. 