### PR TITLE
Add/remove unit and equipment items to a military scenario

### DIFF
--- a/src/lib/forcesides.ts
+++ b/src/lib/forcesides.ts
@@ -138,6 +138,10 @@ export class ForceSide implements ForceSideType {
     return firstUnit.getAffiliation();
   }
 
+  getEquipmentItems(): EquipmentItem[] {
+    return this.equipment;
+  }
+
   getAllUnits(): Unit[] {
     let units: Unit[] = [];
     function addSubordinates(subordinates: Unit[]) {
@@ -198,6 +202,14 @@ export class ForceSide implements ForceSideType {
       }
       if (rootUnit.subordinates) {
         addSubordinates(rootUnit.subordinates);
+      }
+    }
+
+    if (includeEquipment) {
+      for (let equipment of this.equipment) {
+        if (includeEmptyLocations || equipment.location) {
+          features.push(equipment.toGeoJson(options));
+        }
       }
     }
     return { type: "FeatureCollection", features };

--- a/src/test/equipment.test.ts
+++ b/src/test/equipment.test.ts
@@ -320,4 +320,11 @@ describe("New EquipmentItem", () => {
     });
     expect(equipment.location).toEqual([5.0, 54.0]);
   });
+  it("should update from a model", () => {
+    equipment.updateFromObject({
+      name: "Battery",
+      sidc: "SH-------------",
+    });
+    expect(equipment.name, "Relations").toBe("Battery");
+  });
 });


### PR DESCRIPTION
Adds a new Unit or EquipmentmentItem to the <Organizations> of the MSDL. Places it under the primary ForceSide unless specified otherwise. Add tests as well.