### PR TITLE
Fix nesting for msdlOptions

### DIFF
--- a/.changeset/fuzzy-ties-tell.md
+++ b/.changeset/fuzzy-ties-tell.md
@@ -1,0 +1,5 @@
+---
+"@orbat-mapper/msdllib": minor
+---
+
+Add `MilitaryScenario.msdlOptions:MsdlOptions` attribute

--- a/src/lib/msdlOptions.ts
+++ b/src/lib/msdlOptions.ts
@@ -70,7 +70,10 @@ export class MsdlOptions implements MsdlOptionsType {
   set aggregateBased(aggregateBased: string) {
     this.#aggregateBased = aggregateBased;
 
-    let organizationDetailEl = this.ensureChild(this.element, "OrganizationDetail")
+    let organizationDetailEl = this.ensureChild(
+      this.element,
+      "OrganizationDetail",
+    );
     setOrCreateTagValue(organizationDetailEl, "AggregateBased", aggregateBased);
   }
 
@@ -82,9 +85,16 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set aggregateEchelon(aggregateEchelon: string) {
     this.#aggregateEchelon = aggregateEchelon;
-    
-    let organizationDetailEl = this.ensureChild(this.element, "OrganizationDetail")
-    setOrCreateTagValue(organizationDetailEl, "AggregateEchelon", aggregateEchelon);
+
+    let organizationDetailEl = this.ensureChild(
+      this.element,
+      "OrganizationDetail",
+    );
+    setOrCreateTagValue(
+      organizationDetailEl,
+      "AggregateEchelon",
+      aggregateEchelon,
+    );
   }
 
   get standardName(): string {
@@ -94,8 +104,14 @@ export class MsdlOptions implements MsdlOptionsType {
   set standardName(standardName: string) {
     this.#standardName = standardName;
 
-    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
-    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    let scenarioDataStandardsEl = this.ensureChild(
+      this.element,
+      "ScenarioDataStandards",
+    );
+    let symbologyDataStandardEl = this.ensureChild(
+      scenarioDataStandardsEl,
+      "SymbologyDataStandard",
+    );
     setOrCreateTagValue(symbologyDataStandardEl, "StandardName", standardName);
   }
 
@@ -106,8 +122,14 @@ export class MsdlOptions implements MsdlOptionsType {
   set majorVersion(majorVersion: string) {
     this.#majorVersion = majorVersion;
 
-    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
-    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    let scenarioDataStandardsEl = this.ensureChild(
+      this.element,
+      "ScenarioDataStandards",
+    );
+    let symbologyDataStandardEl = this.ensureChild(
+      scenarioDataStandardsEl,
+      "SymbologyDataStandard",
+    );
     setOrCreateTagValue(symbologyDataStandardEl, "MajorVersion", majorVersion);
   }
 
@@ -118,8 +140,14 @@ export class MsdlOptions implements MsdlOptionsType {
   set minorVersion(minorVersion: string) {
     this.#minorVersion = minorVersion;
 
-    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
-    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    let scenarioDataStandardsEl = this.ensureChild(
+      this.element,
+      "ScenarioDataStandards",
+    );
+    let symbologyDataStandardEl = this.ensureChild(
+      scenarioDataStandardsEl,
+      "SymbologyDataStandard",
+    );
     setOrCreateTagValue(symbologyDataStandardEl, "MinorVersion", minorVersion);
   }
 
@@ -133,8 +161,14 @@ export class MsdlOptions implements MsdlOptionsType {
   set coordinateSystemType(coordinateSystemType: string) {
     this.#coordinateSystemType = coordinateSystemType;
 
-    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
-    let CoordinateDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "CoordinateDataStandard")
+    let scenarioDataStandardsEl = this.ensureChild(
+      this.element,
+      "ScenarioDataStandards",
+    );
+    let CoordinateDataStandardEl = this.ensureChild(
+      scenarioDataStandardsEl,
+      "CoordinateDataStandard",
+    );
     setOrCreateTagValue(
       CoordinateDataStandardEl,
       "CoordinateSystemType",
@@ -152,8 +186,14 @@ export class MsdlOptions implements MsdlOptionsType {
   set coordinateSystemDatum(coordinateSystemDatum: string) {
     this.#coordinateSystemDatum = coordinateSystemDatum;
 
-    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
-    let CoordinateDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "CoordinateDataStandard")
+    let scenarioDataStandardsEl = this.ensureChild(
+      this.element,
+      "ScenarioDataStandards",
+    );
+    let CoordinateDataStandardEl = this.ensureChild(
+      scenarioDataStandardsEl,
+      "CoordinateDataStandard",
+    );
     setOrCreateTagValue(
       CoordinateDataStandardEl,
       "CoordinateSystemDatum",
@@ -214,12 +254,12 @@ export class MsdlOptions implements MsdlOptionsType {
     );
   }
 
-  private ensureChild(element : Element, childName : string): Element {
+  private ensureChild(element: Element, childName: string): Element {
     let child = element.querySelector(childName);
     if (!child) {
       child = createEmptyXMLElementFromTagName(childName);
       element.appendChild(child);
     }
-    return child
+    return child;
   }
 }

--- a/src/lib/msdlOptions.ts
+++ b/src/lib/msdlOptions.ts
@@ -69,7 +69,9 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set aggregateBased(aggregateBased: string) {
     this.#aggregateBased = aggregateBased;
-    setOrCreateTagValue(this.element, "AggregateBased", aggregateBased);
+
+    let organizationDetailEl = this.ensureChild(this.element, "OrganizationDetail")
+    setOrCreateTagValue(organizationDetailEl, "AggregateBased", aggregateBased);
   }
 
   get aggregateEchelon(): string {
@@ -80,7 +82,9 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set aggregateEchelon(aggregateEchelon: string) {
     this.#aggregateEchelon = aggregateEchelon;
-    setOrCreateTagValue(this.element, "AggregateEchelon", aggregateEchelon);
+    
+    let organizationDetailEl = this.ensureChild(this.element, "OrganizationDetail")
+    setOrCreateTagValue(organizationDetailEl, "AggregateEchelon", aggregateEchelon);
   }
 
   get standardName(): string {
@@ -89,7 +93,10 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set standardName(standardName: string) {
     this.#standardName = standardName;
-    setOrCreateTagValue(this.element, "StandardName", standardName);
+
+    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
+    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    setOrCreateTagValue(symbologyDataStandardEl, "StandardName", standardName);
   }
 
   get majorVersion(): string {
@@ -98,7 +105,10 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set majorVersion(majorVersion: string) {
     this.#majorVersion = majorVersion;
-    setOrCreateTagValue(this.element, "MajorVersion", majorVersion);
+
+    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
+    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    setOrCreateTagValue(symbologyDataStandardEl, "MajorVersion", majorVersion);
   }
 
   get minorVersion(): string {
@@ -107,7 +117,10 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set minorVersion(minorVersion: string) {
     this.#minorVersion = minorVersion;
-    setOrCreateTagValue(this.element, "MinorVersion", minorVersion);
+
+    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
+    let symbologyDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "SymbologyDataStandard")
+    setOrCreateTagValue(symbologyDataStandardEl, "MinorVersion", minorVersion);
   }
 
   get coordinateSystemType(): string {
@@ -119,8 +132,11 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set coordinateSystemType(coordinateSystemType: string) {
     this.#coordinateSystemType = coordinateSystemType;
+
+    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
+    let CoordinateDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "CoordinateDataStandard")
     setOrCreateTagValue(
-      this.element,
+      CoordinateDataStandardEl,
       "CoordinateSystemType",
       coordinateSystemType,
     );
@@ -135,8 +151,11 @@ export class MsdlOptions implements MsdlOptionsType {
 
   set coordinateSystemDatum(coordinateSystemDatum: string) {
     this.#coordinateSystemDatum = coordinateSystemDatum;
+
+    let scenarioDataStandardsEl = this.ensureChild(this.element, "ScenarioDataStandards")
+    let CoordinateDataStandardEl = this.ensureChild(scenarioDataStandardsEl, "CoordinateDataStandard")
     setOrCreateTagValue(
-      this.element,
+      CoordinateDataStandardEl,
       "CoordinateSystemDatum",
       coordinateSystemDatum,
     );
@@ -193,5 +212,14 @@ export class MsdlOptions implements MsdlOptionsType {
     return new MsdlOptions(
       createEmptyXMLElementFromTagName(MsdlOptions.TAG_NAME),
     );
+  }
+
+  private ensureChild(element : Element, childName : string): Element {
+    let child = element.querySelector(childName);
+    if (!child) {
+      child = createEmptyXMLElementFromTagName(childName);
+      element.appendChild(child);
+    }
+    return child
   }
 }

--- a/src/test/msdllib.test.ts
+++ b/src/test/msdllib.test.ts
@@ -6,13 +6,11 @@ import {
   MilitaryScenario,
   MsdlOptions,
   ScenarioId,
-  MsdlOptions,
 } from "../index.js";
 import {
   EMPTY_SCENARIO,
   MSDL_OPTIONS_TYPE,
   SCENARIO_ID_TYPE,
-  MSDL_OPTIONS_TYPE,
   UNIT_TEMPLATE,
 } from "./testdata.js";
 import fs from "fs/promises";

--- a/src/test/msdllib.test.ts
+++ b/src/test/msdllib.test.ts
@@ -6,11 +6,14 @@ import {
   MilitaryScenario,
   MsdlOptions,
   ScenarioId,
+  MsdlOptions,
 } from "../index.js";
 import {
   EMPTY_SCENARIO,
   MSDL_OPTIONS_TYPE,
   SCENARIO_ID_TYPE,
+  MSDL_OPTIONS_TYPE,
+  UNIT_TEMPLATE,
 } from "./testdata.js";
 import fs from "fs/promises";
 import {

--- a/src/test/msdloptions.test.ts
+++ b/src/test/msdloptions.test.ts
@@ -129,9 +129,11 @@ describe("MsdlOptions nesting", () => {
     options.aggregateBased = "TestValue";
     expect(options.element.querySelector("OrganizationDetail")).not.toBeNull();
 
-    const aggregateBased = options.element.querySelector("OrganizationDetail")?.querySelector("AggregateBased");
+    const aggregateBased = options.element
+      .querySelector("OrganizationDetail")
+      ?.querySelector("AggregateBased");
     expect(aggregateBased).not.toBeNull();
-    expect(getTagValue(options.element, "AggregateBased")).toBe("TestValue")
+    expect(getTagValue(options.element, "AggregateBased")).toBe("TestValue");
   });
 
   it("should handle nesting correctly for the ScenarioDataStandards element", () => {
@@ -140,21 +142,33 @@ describe("MsdlOptions nesting", () => {
 
     options.standardName = "New Standard";
     options.coordinateSystemDatum = "New Datum";
-    expect(options.element.querySelector("ScenarioDataStandards")).not.toBeNull();
+    expect(
+      options.element.querySelector("ScenarioDataStandards"),
+    ).not.toBeNull();
 
-    const standardName = options.element.querySelector("ScenarioDataStandards")?.querySelector("SymbologyDataStandard")?.querySelector("StandardName");
-    const coordinateSystemDatum = options.element.querySelector("ScenarioDataStandards")?.querySelector("CoordinateDataStandard")?.querySelector("CoordinateSystemDatum");
+    const standardName = options.element
+      .querySelector("ScenarioDataStandards")
+      ?.querySelector("SymbologyDataStandard")
+      ?.querySelector("StandardName");
+    const coordinateSystemDatum = options.element
+      .querySelector("ScenarioDataStandards")
+      ?.querySelector("CoordinateDataStandard")
+      ?.querySelector("CoordinateSystemDatum");
     expect(standardName).not.toBeNull();
     expect(coordinateSystemDatum).not.toBeNull();
 
-    expect(getTagValue(options.element, "StandardName")).toBe("New Standard")
-    expect(getTagValue(options.element, "CoordinateSystemDatum")).toBe("New Datum")
+    expect(getTagValue(options.element, "StandardName")).toBe("New Standard");
+    expect(getTagValue(options.element, "CoordinateSystemDatum")).toBe(
+      "New Datum",
+    );
   });
 
   it("should handle nesting within the XML correctly", () => {
-    const options_template = new MsdlOptions(parseFromString(MSDL_OPTIONS_TEMPLATE));
+    const options_template = new MsdlOptions(
+      parseFromString(MSDL_OPTIONS_TEMPLATE),
+    );
     const options_empty = new MsdlOptions(parseFromString(MSDL_OPTIONS_EMPTY));
-    options_empty.msdlVersion = "1.0.2";      
+    options_empty.msdlVersion = "1.0.2";
     options_empty.standardName = "MILSTD_2525B";
     options_empty.majorVersion = "2";
     options_empty.minorVersion = "3";
@@ -163,9 +177,16 @@ describe("MsdlOptions nesting", () => {
     options_empty.aggregateBased = "value";
     options_empty.aggregateEchelon = "FRONT";
 
-    const flat_options_template = options_template.toString().replaceAll('  ', ' ').replace(/>\s+</g, '><')
-    const flat_options_emtpy = options_empty.toString().replaceAll('  ', ' ').replace(/>\s+</g, '><').replaceAll(' xmlns=""', '')
-    expect(flat_options_emtpy).toBe(flat_options_template)
+    const flat_options_template = options_template
+      .toString()
+      .replaceAll("  ", " ")
+      .replace(/>\s+</g, "><");
+    const flat_options_emtpy = options_empty
+      .toString()
+      .replaceAll("  ", " ")
+      .replace(/>\s+</g, "><")
+      .replaceAll(' xmlns=""', "");
+    expect(flat_options_emtpy).toBe(flat_options_template);
   });
 });
 


### PR DESCRIPTION
This PR fixes the issues i had with the nesting behavior. When merged the PR on the MSLD editor with respect to the Options Editing Tab can be merged as well (after the current PR) : [https://github.com/orbat-mapper/msdl-editor/pull/51](MSLD editor PR)